### PR TITLE
from llama_index.core import modules after v0.10.x

### DIFF
--- a/BCEmbedding/tools/llama_index/bce_rerank.py
+++ b/BCEmbedding/tools/llama_index/bce_rerank.py
@@ -8,10 +8,10 @@
 from typing import Any, List, Optional
 
 from pydantic.v1 import Field, PrivateAttr
-from llama_index.callbacks import CBEventType, EventPayload
-from llama_index.postprocessor.types import BaseNodePostprocessor
-from llama_index.schema import MetadataMode, NodeWithScore, QueryBundle
-from llama_index.utils import infer_torch_device
+from llama_index.core.callbacks import CBEventType, EventPayload
+from llama_index.core.postprocessor.types import BaseNodePostprocessor
+from llama_index.core.schema import MetadataMode, NodeWithScore, QueryBundle
+from llama_index.core.utils import infer_torch_device
 
 
 class BCERerank(BaseNodePostprocessor):


### PR DESCRIPTION
Dear netease-youdao team,

  LlamaIndex v0.10.x have integrated all modules used by bce_rerank.py into llama_index.core, which is declared in https://github.com/run-llama/llama_index/releases/tag/v0.10.1.

  It's advisable to rewrite llama_index.callbacks to llama_index.core.callbacks.
  
  The modification has been certified feasible in my project after tested in LlamaIndex v0.10.29 and v0.10.52(latest).
  
  Thanks for providing us with the llama index interface.