### PR TITLE
Update embedding.py to support Intel Arc Graphics Card

### DIFF
--- a/BCEmbedding/models/embedding.py
+++ b/BCEmbedding/models/embedding.py
@@ -2,8 +2,8 @@
 @Description: 
 @Author: shenlei
 @Date: 2023-11-28 14:04:27
-@LastEditTime: 2024-05-13 17:04:23
-@LastEditors: shenlei
+@LastEditTime: 2024-09-02 22:32:01
+@LastEditors: Chengjie Guo i@guoch.xyz
 '''
 import logging
 import torch
@@ -45,6 +45,9 @@ class EmbeddingModel:
             self.num_gpus = 1
         elif self.device == "cuda":
             self.num_gpus = num_gpus
+        elif self.device == "xpu":
+            import intel_extension_for_pytorch as ipex
+            self.num_gpus = 0
         else:
             raise ValueError("Please input valid device: 'cpu', 'cuda', 'cuda:0', '0' !")
 
@@ -53,6 +56,9 @@ class EmbeddingModel:
 
         self.model.eval()
         self.model = self.model.to(self.device)
+        
+        if self.device == "xpu":
+            self.model = ipex.optimize(self.model)
 
         if self.num_gpus > 1:
             self.model = torch.nn.DataParallel(self.model)


### PR DESCRIPTION
It was tested to work on Intel Arc A770 16GB GPU with the latest oneAPI setup.  
Intel® oneAPI Base Toolkit: 2024.2.1  
Python: 3.11  
Windows 11 with driver [Intel® Arc™ & Iris® Xe Graphics - WHQL - Windows* 32.0.101.5768](https://www.intel.com/content/www/us/en/download/785597/intel-arc-iris-xe-graphics-windows.html)

Reference: https://intel.github.io/intel-extension-for-pytorch/index.html#installation?platform=gpu&version=v2.1.40%2bxpu&os=windows&package=pip