### PR TITLE
Adaptation for llama-index > 0.10

### DIFF
--- a/BCEmbedding/tools/llama_index/bce_rerank.py
+++ b/BCEmbedding/tools/llama_index/bce_rerank.py
@@ -2,20 +2,20 @@
 @Description: 
 @Author: shenlei
 @Date: 2024-01-15 14:15:30
-@LastEditTime: 2024-03-04 16:00:52
-@LastEditors: shenlei
+@LastEditTime: 2024-09-06 13:25:04
+@LastEditors: Innary
 '''
 from typing import Any, List, Optional
 
-from pydantic.v1 import Field, PrivateAttr
-from llama_index.callbacks import CBEventType, EventPayload
-from llama_index.postprocessor.types import BaseNodePostprocessor
-from llama_index.schema import MetadataMode, NodeWithScore, QueryBundle
-from llama_index.utils import infer_torch_device
+from llama_index.core.bridge.pydantic import Field, PrivateAttr
+from llama_index.core.callbacks import CBEventType, EventPayload
+from llama_index.core.postprocessor.types import BaseNodePostprocessor
+from llama_index.core.schema import MetadataMode, NodeWithScore, QueryBundle
+from llama_index.core.utils import infer_torch_device
 
 
 class BCERerank(BaseNodePostprocessor):
-    model: str = Field(ddescription="Sentence transformer model name.")
+    model: str = Field(description="Sentence transformer model name.")
     top_n: int = Field(description="Number of nodes to return sorted by score.")
     _model: Any = PrivateAttr()
 
@@ -33,9 +33,10 @@ class BCERerank(BaseNodePostprocessor):
                 "Cannot import `BCEmbedding` package,",
                 "please `pip install BCEmbedding>=0.1.2`",
             )
-        self._model = RerankerModel(model_name_or_path=model, device=device, **kwargs)
         device = infer_torch_device() if device is None else device
         super().__init__(top_n=top_n, model=model, device=device)
+        self._model = RerankerModel(model_name_or_path=model, device=device, **kwargs)
+
 
     @classmethod
     def class_name(cls) -> str:


### PR DESCRIPTION
Dear netease-youdao team,

The llama-index part of the code has been deprecated since v0.10.x again, so I'm submitting that code.

This modification allows the BCERerank NodePostprocessor to work properly with llama_index versions higher than v0.10.x

The modification has been certified feasible in my project after tested in LlamaIndex v0.11.6(latest).